### PR TITLE
VegaFusion: Arrow 28.0 with fixes

### DIFF
--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -1679,7 +1679,7 @@ mod tests {
             let list_data = ArrayData::builder(list_data_type.clone())
                 .len(4)
                 .add_buffer(value_offsets)
-                .null_bit_buffer(Some(Buffer::from([0b01111101])))
+                .null_bit_buffer(Some(Buffer::from([0b11111011])))
                 .add_child_data(value_data)
                 .build()
                 .unwrap();

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -1606,7 +1606,7 @@ mod tests {
             let list_data = ArrayData::builder(list_data_type.clone())
                 .len(4)
                 .add_buffer(value_offsets)
-                .null_bit_buffer(Some(Buffer::from([0b10111101, 0b00000000])))
+                .null_bit_buffer(Some(Buffer::from([0b11111111])))
                 .add_child_data(value_data)
                 .build()
                 .unwrap();

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -1518,12 +1518,12 @@ mod tests {
 
     macro_rules! test_take_list {
         ($offset_type:ty, $list_data_type:ident, $list_array_type:ident) => {{
-            // Construct a value array, [[0,0,0], [-1,-2,-1], [2,3]]
+            // Construct a value array, [[0,0,0], [-1,-2,-1], [], [2,3]]
             let value_data = Int32Array::from(vec![0, 0, 0, -1, -2, -1, 2, 3])
                 .data()
                 .clone();
             // Construct offsets
-            let value_offsets: [$offset_type; 4] = [0, 3, 6, 8];
+            let value_offsets: [$offset_type; 5] = [0, 3, 6, 6, 8];
             let value_offsets = Buffer::from_slice_ref(&value_offsets);
             // Construct a list array from the above two
             let list_data_type = DataType::$list_data_type(Box::new(Field::new(
@@ -1532,30 +1532,28 @@ mod tests {
                 false,
             )));
             let list_data = ArrayData::builder(list_data_type.clone())
-                .len(3)
+                .len(4)
                 .add_buffer(value_offsets)
                 .add_child_data(value_data)
                 .build()
                 .unwrap();
             let list_array = $list_array_type::from(list_data);
 
-            // index returns: [[2,3], null, [-1,-2,-1], [2,3], [0,0,0]]
-            let index = UInt32Array::from(vec![Some(2), None, Some(1), Some(2), Some(0)]);
+            // index returns: [[2,3], null, [-1,-2,-1], [], [0,0,0]]
+            let index = UInt32Array::from(vec![Some(3), None, Some(1), Some(2), Some(0)]);
 
             let a = take(&list_array, &index, None).unwrap();
             let a: &$list_array_type =
                 a.as_any().downcast_ref::<$list_array_type>().unwrap();
 
             // construct a value array with expected results:
-            // [[2,3], null, [-1,-2,-1], [2,3], [0,0,0]]
+            // [[2,3], null, [-1,-2,-1], [], [0,0,0]]
             let expected_data = Int32Array::from(vec![
                 Some(2),
                 Some(3),
                 Some(-1),
                 Some(-2),
                 Some(-1),
-                Some(2),
-                Some(3),
                 Some(0),
                 Some(0),
                 Some(0),
@@ -1563,7 +1561,7 @@ mod tests {
             .data()
             .clone();
             // construct offsets
-            let expected_offsets: [$offset_type; 6] = [0, 2, 2, 5, 7, 10];
+            let expected_offsets: [$offset_type; 6] = [0, 2, 2, 5, 5, 8];
             let expected_offsets = Buffer::from_slice_ref(&expected_offsets);
             // construct list array from the two
             let expected_list_data = ArrayData::builder(list_data_type)

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -694,7 +694,7 @@ where
         take_value_indices_from_list::<IndexType, OffsetType>(values, indices)?;
 
     let taken = take_impl::<OffsetType>(values.values().as_ref(), &list_indices, None)?;
-    let value_offsets = Buffer::from_slice_ref(&offsets);
+    let value_offsets = Buffer::from_slice_ref(offsets);
     // create a new list with taken data and computed null information
     let list_data = ArrayDataBuilder::new(values.data_type().clone())
         .len(indices.len())
@@ -814,6 +814,7 @@ where
 /// Where a list array has indices `[0,2,5,10]`, taking indices of `[2,0]` returns
 /// an array of the indices `[5..10, 0..2]` and offsets `[0,5,7]` (5 elements and 2
 /// elements)
+#[allow(clippy::type_complexity)]
 fn take_value_indices_from_list<IndexType, OffsetType>(
     list: &GenericListArray<OffsetType::Native>,
     indices: &PrimitiveArray<IndexType>,

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -814,15 +814,17 @@ where
 /// Where a list array has indices `[0,2,5,10]`, taking indices of `[2,0]` returns
 /// an array of the indices `[5..10, 0..2]` and offsets `[0,5,7]` (5 elements and 2
 /// elements)
+///
+/// Returns tuple of (values, offsets, null buffer)
 #[allow(clippy::type_complexity)]
 fn take_value_indices_from_list<IndexType, OffsetType>(
     list: &GenericListArray<OffsetType::Native>,
     indices: &PrimitiveArray<IndexType>,
 ) -> Result<
     (
-        PrimitiveArray<OffsetType>,
-        Vec<OffsetType::Native>,
-        MutableBuffer,
+        PrimitiveArray<OffsetType>, // Inner list values
+        Vec<OffsetType::Native>,    // Offsets
+        MutableBuffer,              // Null buffer
     ),
     ArrowError,
 >


### PR DESCRIPTION
This branch is for use by VegaFusion. It is version 28.0 of arrow-rs with the following fixes backported:

 - https://github.com/apache/arrow-rs/pull/3473
